### PR TITLE
Update sails.service.ts

### DIFF
--- a/src/sails.service.ts
+++ b/src/sails.service.ts
@@ -7,7 +7,7 @@ declare let io:any;
 if (io && io.sails) {
 
 
-  if (io && io.socket && io.socket.isConnected) {
+  if (io && io.socket && io.socket.isConnected()) {
     io.socket.disconnect();
   }
 


### PR DESCRIPTION
In this block isConnected will always be true so disconnect is always called. sails.io.js then throws if the socket hasn't been established.

throw new Error('Cannot disconnect- socket is already disconnected');

if (io && io.sails) {
    if (io && io.socket && io.socket.isConnected) {
        io.socket.disconnect();
    }
}

to

if (io && io.sails) {
    if (io && io.socket && io.socket.isConnected()) {
        io.socket.disconnect();
    }
}
